### PR TITLE
Update teamsphisher.py with new Bypass Technique

### DIFF
--- a/teamsphisher.py
+++ b/teamsphisher.py
@@ -408,8 +408,7 @@ def removeExternalUser(skypeToken, senderInfo, threadID, targetInfo):
 
     # Delete the target user from the thread
     content = requests.delete(f"https://amer.ng.msg.teams.microsoft.com/v1/threads/{threadID}/members/{targetInfo.get('mri')}", headers=headers)
-    print(content.text)
-    if content.status_code != 204:
+    if content.status_code != 204 and content.status_code != 200:
         p_warn("Error removing user: %d" % (content.status_code))
         p_warn(content.text)
         return None


### PR DESCRIPTION
**Purpose:**
There is a new Teams message warning bypass which requires users to send a message and remove themselves from the group chat. The previous bypass was patched by Microsoft which results in external users to receive a  warning banner.

TeamsPhisher already invites the user twice, so the only modification was to create a new function. Users of TeamsPhisher may want to keep the message warning depending on the pretext and what they are attempting to accomplish. I have not created an option to do this yet.

**Main Change:**
Created a new function called removeExternalUser which deletes the "targetInfo" member once a chat is created. This function is called on line 804 once a new real thread/message is sent. 

`removeExternalUser(skypeToken, senderInfo, threadID, targetInfo)`

**Bypass Details**
[pfiatde blog](https://badoption.eu/blog/2024/01/12/teams5.html)
Credit: https://twitter.com/pfiatde
Original Tweet: https://x.com/pfiatde/status/1745821948787974481?s=20

**Tests Ran:**
- Sent a test message to an external user using the original TeamsPhisher code and verified splash warning was present
- Ran same test against same target and was able to bypass splash warning by leveraging new function

Assisted by DenSecure team @stevesec and @almart 